### PR TITLE
Kakao API URL 수정

### DIFF
--- a/lib/omniauth/strategies/kakao.rb
+++ b/lib/omniauth/strategies/kakao.rb
@@ -45,7 +45,7 @@ module OmniAuth
 
     private
       def raw_info
-        @raw_info ||= access_token.get('https://kapi.kakao.com/v1/user/me', {}).parsed || {}
+        @raw_info ||= access_token.get('https://kapi.kakao.com/v2/user/me', {}).parsed || {}
       end
 
       def raw_properties


### PR DESCRIPTION
Profile을 가져오는 API 주소가 https://kapi.kakao.com/v2/user/me 로 변경되었습니다.